### PR TITLE
[BUG] fixing panic when route not found

### DIFF
--- a/ngamux.go
+++ b/ngamux.go
@@ -135,10 +135,6 @@ func (r *Ngamux) addRoute(method string, route Route) {
 }
 
 func (r *Ngamux) getRoute(method string, path string) Route {
-	foundRoute := Route{
-		Handler: r.config.NotFoundHandler,
-	}
-
 	foundRoute, ok := r.routes[method][path]
 	if !ok {
 		for url, route := range r.routesParam[method] {
@@ -160,6 +156,10 @@ func (r *Ngamux) getRoute(method string, path string) Route {
 				break
 			}
 		}
+	}
+
+	if foundRoute.Handler == nil {
+		foundRoute.Handler = r.config.NotFoundHandler
 	}
 
 	return foundRoute


### PR DESCRIPTION
# Describe The Bug

`foundRoute` handler is replaced with nil whenever a route is not found

# To Reproduce

1. Run `example/basic/basic.go`
2. Access unregistered endpoint (e.g: https://localhost:8080/foobar)
3. Golang panics

# Expected Behavior
`r.config.NotFoundHandler` is called

# Additional Context

https://github.com/ngamux/ngamux/blob/5f35c09b6819d402a387089d3d578b282499e2a1/ngamux.go#L138-L142
the `foundroute` is always replaced

