### PR TITLE
[FEATURE] implementing global middleware

### DIFF
--- a/example/basic/basic.go
+++ b/example/basic/basic.go
@@ -9,12 +9,15 @@ import (
 
 func main() {
 	mux := ngamux.NewNgamux()
-	mux.Get("/", func(rw http.ResponseWriter, r *http.Request) {
+
+	mux.Get("/", func(rw http.ResponseWriter, r *http.Request) error {
 		fmt.Fprintln(rw, "GET /")
+		return nil
 	})
 
-	mux.Get("/users", func(rw http.ResponseWriter, r *http.Request) {
+	mux.Get("/users", func(rw http.ResponseWriter, r *http.Request) error {
 		fmt.Fprintln(rw, "GET /users")
+		return nil
 	})
 
 	http.ListenAndServe(":8080", mux)

--- a/example/body/body.go
+++ b/example/body/body.go
@@ -9,17 +9,18 @@ import (
 
 func main() {
 	mux := ngamux.NewNgamux()
-	mux.Get("/", func(rw http.ResponseWriter, r *http.Request) {
+	mux.Get("/", func(rw http.ResponseWriter, r *http.Request) error {
 		fmt.Fprintln(rw, "GET /")
+		return nil
 	})
 
-	mux.Post("/", func(rw http.ResponseWriter, r *http.Request) {
+	mux.Post("/", func(rw http.ResponseWriter, r *http.Request) error {
 		in := map[string]string{}
 		err := ngamux.GetBody(r, &in)
 		if err != nil {
 			ngamux.JSONWithStatus(rw, http.StatusBadRequest, err.Error())
 		}
-		ngamux.JSON(rw, in)
+		return ngamux.JSON(rw, in)
 	})
 
 	http.ListenAndServe(":8080", mux)

--- a/example/group/group.go
+++ b/example/group/group.go
@@ -10,8 +10,9 @@ import (
 func main() {
 	mux := ngamux.NewNgamux()
 	users := mux.Group("/users")
-	users.Get("/", func(rw http.ResponseWriter, r *http.Request) {
+	users.Get("/", func(rw http.ResponseWriter, r *http.Request) error {
 		fmt.Fprintln(rw, "GET /users")
+		return nil
 	})
 
 	http.ListenAndServe(":8080", mux)

--- a/example/middleware/middleware.go
+++ b/example/middleware/middleware.go
@@ -19,10 +19,10 @@ func main() {
 		RemoveTrailingSlash: true,
 	})
 
-	mux.Use(func(handlerFunc ngamux.HandlerFunc) ngamux.HandlerFunc {
+	mux.Use(func(next ngamux.HandlerFunc) ngamux.HandlerFunc {
 		return func(rw http.ResponseWriter, r *http.Request) error {
 			fmt.Println("hello from middleware")
-			return handlerFunc(rw, r)
+			return next(rw, r)
 		}
 	})
 

--- a/example/middleware/middleware.go
+++ b/example/middleware/middleware.go
@@ -21,7 +21,7 @@ func main() {
 
 	mux.Use(func(next ngamux.HandlerFunc) ngamux.HandlerFunc {
 		return func(rw http.ResponseWriter, r *http.Request) error {
-			fmt.Println("hello from middleware")
+			fmt.Println("hello from middleware 1")
 			return next(rw, r)
 		}
 	})
@@ -31,21 +31,6 @@ func main() {
 		fmt.Println("hello from handler")
 		return nil
 	})
-
-	//users := mux.Group("/users")
-	//users.Get("/",
-	//	MiddlewareHello(
-	//		MiddlewareHello(
-	//			MiddlewareHello(
-	//				MiddlewareHello(
-	//					func(rw http.ResponseWriter, r *http.Request) {
-	//						fmt.Fprintln(rw, "hello from users handler")
-	//					},
-	//				),
-	//			),
-	//		),
-	//	),
-	//)
 
 	http.ListenAndServe(":8080", mux)
 }

--- a/example/middleware/middleware.go
+++ b/example/middleware/middleware.go
@@ -7,13 +7,6 @@ import (
 	"github.com/ngamux/ngamux"
 )
 
-func MiddlewareHello(handler http.HandlerFunc) http.HandlerFunc {
-	return func(rw http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(rw, "hello from middleware")
-		handler(rw, r)
-	}
-}
-
 func main() {
 	mux := ngamux.NewNgamux(ngamux.Config{
 		RemoveTrailingSlash: true,

--- a/example/middleware/middleware.go
+++ b/example/middleware/middleware.go
@@ -19,34 +19,33 @@ func main() {
 		RemoveTrailingSlash: true,
 	})
 
-	mux.Get("/",
-		MiddlewareHello(
-			MiddlewareHello(
-				MiddlewareHello(
-					MiddlewareHello(
-						func(rw http.ResponseWriter, r *http.Request) {
-							fmt.Fprintln(rw, "hello from handler")
-						},
-					),
-				),
-			),
-		),
-	)
+	mux.Use(func(handlerFunc ngamux.HandlerFunc) ngamux.HandlerFunc {
+		return func(rw http.ResponseWriter, r *http.Request) error {
+			fmt.Println("hello from middleware")
+			return handlerFunc(rw, r)
+		}
+	})
 
-	users := mux.Group("/users")
-	users.Get("/",
-		MiddlewareHello(
-			MiddlewareHello(
-				MiddlewareHello(
-					MiddlewareHello(
-						func(rw http.ResponseWriter, r *http.Request) {
-							fmt.Fprintln(rw, "hello from users handler")
-						},
-					),
-				),
-			),
-		),
-	)
+	mux.Get("/", func(rw http.ResponseWriter, r *http.Request) error {
+		fmt.Fprintln(rw, "hello from users handler")
+		fmt.Println("hello from handler")
+		return nil
+	})
+
+	//users := mux.Group("/users")
+	//users.Get("/",
+	//	MiddlewareHello(
+	//		MiddlewareHello(
+	//			MiddlewareHello(
+	//				MiddlewareHello(
+	//					func(rw http.ResponseWriter, r *http.Request) {
+	//						fmt.Fprintln(rw, "hello from users handler")
+	//					},
+	//				),
+	//			),
+	//		),
+	//	),
+	//)
 
 	http.ListenAndServe(":8080", mux)
 }

--- a/example/middleware/middleware.go
+++ b/example/middleware/middleware.go
@@ -21,7 +21,7 @@ func main() {
 
 	mux.Use(func(next ngamux.HandlerFunc) ngamux.HandlerFunc {
 		return func(rw http.ResponseWriter, r *http.Request) error {
-			fmt.Println("hello from middleware 1")
+			fmt.Println("hello from middleware")
 			return next(rw, r)
 		}
 	})

--- a/group.go
+++ b/group.go
@@ -11,27 +11,27 @@ type group struct {
 	middlewares []http.HandlerFunc
 }
 
-func (mux *group) Get(url string, handler http.HandlerFunc) {
+func (mux *group) Get(url string, handler HandlerFunc) {
 	url = path.Join(mux.path, url)
 	mux.parent.Get(url, handler)
 }
 
-func (mux *group) Post(url string, handler http.HandlerFunc) {
+func (mux *group) Post(url string, handler HandlerFunc) {
 	url = path.Join(mux.path, url)
 	mux.parent.Post(url, handler)
 }
 
-func (mux *group) Patch(url string, handler http.HandlerFunc) {
+func (mux *group) Patch(url string, handler HandlerFunc) {
 	url = path.Join(mux.path, url)
 	mux.parent.Patch(url, handler)
 }
 
-func (mux *group) Put(url string, handler http.HandlerFunc) {
+func (mux *group) Put(url string, handler HandlerFunc) {
 	url = path.Join(mux.path, url)
 	mux.parent.Put(url, handler)
 }
 
-func (mux *group) Delete(url string, handler http.HandlerFunc) {
+func (mux *group) Delete(url string, handler HandlerFunc) {
 	url = path.Join(mux.path, url)
 	mux.parent.Delete(url, handler)
 }


### PR DESCRIPTION
for implement global middleware, we can use method for assign middleware to route/handler

example:
```javascript
mux.Use(func(next ngamux.HandlerFunc) ngamux.HandlerFunc {
	return func(rw http.ResponseWriter, r *http.Request) error {
		fmt.Println("hello from middleware")
		return next(rw, r)
	}
})
```